### PR TITLE
fixed mask bug for ww3 grid spec

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1457,10 +1457,7 @@
 
   <model_grid alias="TL319_wtn14100k" not_compset="_CAM|_MOM|_POP">
     <grid name="atm">TL319</grid>
-    <grid name="ocnice">tnx1v4</grid>
     <grid name="wav">wise.tnx1v4p.100k</grid>
-    <grid name="rof">JRA025</grid>
-    <mask>tnx1v4</mask>
     <mask>wise.tnx1v4p.100k</mask>
   </model_grid>
 


### PR DESCRIPTION
This PR fixes a duplicate mask for a refined ww3 model grid alias.