### PR TITLE
Use external PIO build in ESMF8.4.1.

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3670,20 +3670,19 @@ This allows using a different mpirun command to launch unit tests
         <command name="--force purge"></command>
         <command name="load">StdEnv</command>
         <command name="use">/cluster/projects/nn9560k/mdeb/extra_mods/modules/all</command>
-        <command name="load">ESMF/8.4.1-iomkl-2021b</command>
+        <command name="load">ESMF/8.4.1-iomkl-2021b-ParallelIO-2.5.10</command>
         <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
         <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
-        <command name="load">PnetCDF/1.12.3-iompi-2021b</command>
+
         <command name="load">ParMETIS/4.0.3-iompi-2021b</command>
       </modules>
       <modules compiler="intel" mpilib="impi">
         <command name="--force purge"></command>
         <command name="load">StdEnv</command>
         <command name="use">/cluster/projects/nn9560k/mdeb/extra_mods/modules/all</command>
-        <command name="load">ESMF/8.4.1-intel-2021b</command>
+        <command name="load">ESMF/8.4.1-intel-2021b-ParallelIO-2.5.10</command>
         <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
         <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
-        <command name="load">PnetCDF/1.12.3-iimpi-2021b</command>
         <command name="load">ParMETIS/4.0.3-iimpi-2021b</command>
       </modules>
     </module_system>
@@ -3748,10 +3747,9 @@ This allows using a different mpirun command to launch unit tests
         <command name="--force purge"></command>
         <command name="load">StdEnv</command>
         <command name="use">/cluster/projects/nn9560k/mdeb/extra_mods/modules/all</command>
-        <command name="load">ESMF/8.4.1-intel-2021b</command>
+        <command name="load">ESMF/8.4.1-intel-2021b-ParallelIO-2.5.10</command>
         <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
         <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
-        <command name="load">PnetCDF/1.12.3-iimpi-2021b</command>
         <command name="load">ParMETIS/4.0.3-iimpi-2021b</command>
       </modules>
     </module_system>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3765,6 +3765,10 @@ This allows using a different mpirun command to launch unit tests
       <env name="ESMF_LIBDIR">$ENV{EBROOTESMF}/lib</env>
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
       <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
+      <env name="PIO_VERSION_MAJOR">2</env>
+      <env name="PIO_LIBDIR">$ENV{EBROOTPARALLELIO}/lib</env>
+      <env name="PIO_INCDIR">$ENV{EBROOTPARALLELIO}/include</env>
+      <env name="PIO_TYPENAME_VALID_VALUES">pnetcdf,netcdf,netcdf4p,netcdf4c</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3687,8 +3687,17 @@ This allows using a different mpirun command to launch unit tests
       </modules>
     </module_system>
     <environment_variables>
+      <env name="ESMFMKFILE">$ENV{EBROOTESMF}/lib/esmf.mk</env>
+      <env name="ESMF_RUNTIME_PROFILE">ON</env>
+      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
+      <env name="HCOLL_MAIN_IB">mlx5_0:1</env>
+      <env name="HCOLL_ENABLE_MCAST">1</env>
       <env name="KMP_STACKSIZE">64M</env>
       <env name="MKL_DEBUG_CPU_TYPE">5</env>
+      <env name="PIO_VERSION_MAJOR">2</env>
+      <env name="PIO_LIBDIR">$ENV{EBROOTPARALLELIO}/lib</env>
+      <env name="PIO_INCDIR">$ENV{EBROOTPARALLELIO}/include</env>
+      <env name="PIO_TYPENAME_VALID_VALUES">pnetcdf,netcdf,netcdf4p,netcdf4c</env>
       <env name="OMPI_MCA_mpi_leave_pinned">1</env>
       <env name="OMPI_MCA_btl">self,vader</env>
       <env name="OMPI_MCA_rmaps_rank_file_physical">1</env>
@@ -3696,11 +3705,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="OMPI_MCA_coll">^fca</env>
       <env name="OMPI_MCA_coll_hcoll_priority">95</env>
       <env name="OMPI_MCA_coll_hcoll_np">8</env>
-      <env name="HCOLL_MAIN_IB">mlx5_0:1</env>
-      <env name="HCOLL_ENABLE_MCAST_ALL">1</env>
-      <env name="ESMFMKFILE">$ENV{EBROOTESMF}/lib/esmf.mk</env>
-      <env name="ESMF_RUNTIME_PROFILE">ON</env>
-      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
       <env name="OMPI_222MCA222222_io">ompio</env>
       <env name="OMPI_MCA_fs_lustre_stripe_size">1048576</env>
       <env name="OMPI_MCA_fs_lustre_stripe_width">8</env>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3706,8 +3706,8 @@ This allows using a different mpirun command to launch unit tests
       <env name="OMPI_MCA_coll_hcoll_priority">95</env>
       <env name="OMPI_MCA_coll_hcoll_np">8</env>
       <env name="OMPI_222MCA222222_io">ompio</env>
-      <env name="OMPI_MCA_fs_lustre_stripe_size">1048576</env>
-      <env name="OMPI_MCA_fs_lustre_stripe_width">8</env>
+      <!--env name="OMPI_MCA_fs_lustre_stripe_size">1048576</env-->
+      <!--env name="OMPI_MCA_fs_lustre_stripe_width">8</env-->
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>


### PR DESCRIPTION
Updated config_machines to allow ESMF use of external PIO build.
Also gets rid of the lfs setstripe warnings.