### PR TITLE
Update path to ESMF modules

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3669,7 +3669,7 @@ This allows using a different mpirun command to launch unit tests
       <modules compiler="intel" mpilib="openmpi">
         <command name="--force purge"></command>
         <command name="load">StdEnv</command>
-        <command name="use">/cluster/projects/nn9560k/mdeb/extra_mods/modules/all</command>
+        <command name="use">/cluster/shared/noresm/eb_mods/modules/all</command>
         <command name="load">ESMF/8.4.1-iomkl-2021b-ParallelIO-2.5.10</command>
         <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
         <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
@@ -3679,7 +3679,7 @@ This allows using a different mpirun command to launch unit tests
       <modules compiler="intel" mpilib="impi">
         <command name="--force purge"></command>
         <command name="load">StdEnv</command>
-        <command name="use">/cluster/projects/nn9560k/mdeb/extra_mods/modules/all</command>
+        <command name="use">/cluster/shared/noresm/eb_mods/modules/all</command>
         <command name="load">ESMF/8.4.1-intel-2021b-ParallelIO-2.5.10</command>
         <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
         <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
@@ -3750,7 +3750,7 @@ This allows using a different mpirun command to launch unit tests
       <modules>
         <command name="--force purge"></command>
         <command name="load">StdEnv</command>
-        <command name="use">/cluster/projects/nn9560k/mdeb/extra_mods/modules/all</command>
+        <command name="use">/cluster/shared/noresm/eb_mods/modules/all</command>
         <command name="load">ESMF/8.4.1-intel-2021b-ParallelIO-2.5.10</command>
         <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
         <command name="load">Python/3.9.6-GCCcore-11.2.0</command>


### PR DESCRIPTION
Moved ESMF modules on betzy and fram to allow people without a certain project assess to use CESM.