### PR TITLE
Add NODENAME_REGEX for Betzy

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3635,6 +3635,7 @@ This allows using a different mpirun command to launch unit tests
 
   <machine MACH="betzy">
     <DESC> BullSequana XH2000 AMD® Epyc™ "Rome" 2.2GHz, 128-way nodes, os is Linux, batch system is SLURM</DESC>
+    <NODENAME_REGEX>.*.?betzy\d?.sigma2.no</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS compiler="intel" >openmpi,impi</MPILIBS>


### PR DESCRIPTION
In order for CIME command-line scripts to find the correct entry in the machines file (config_machines.xml), the entry for Betzy was generalized with a `NODENAME_REGEX` entry.