### PR TITLE
update modules fram

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3753,11 +3753,12 @@ This allows using a different mpirun command to launch unit tests
       <modules>
         <command name="--force purge"></command>
         <command name="load">StdEnv</command>
-        <command name="use">/cluster/shared/noresm/eb_mods/modules/all</command>
-        <command name="load">ESMF/8.4.1-intel-2021b-ParallelIO-2.5.10</command>
-        <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
-        <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
-        <command name="load">ParMETIS/4.0.3-iimpi-2021b</command>
+        <command name="use">/cluster/shared/noresm/eb_mods/modules/all/</command>
+        <command name="load">CMake/3.23.1-GCCcore-11.3.0</command>
+        <command name="load">Python/3.10.4-GCCcore-11.3.0</command>
+        <command name="load">XML-LibXML/2.0207-GCCcore-11.3.0</command>
+        <command name="load">ESMF/8.4.1-intel-2022a-ParallelIO-2.5.10</command>
+        <!--command name="load">ParMETIS/4.0.3-iimpi-2021b</command-->
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
New ESMF built with intel/2022a toolchain. 
XML-libXML was also rebuild since the default module is corrupted. Asked sigma2 to fix it, however will be using custom built one for now.