### PR TITLE
new module for betzy needed for clm namelist generation

### DIFF
--- a/machines/betzy/config_machines.xml
+++ b/machines/betzy/config_machines.xml
@@ -33,32 +33,35 @@
     <modules compiler="intel-oneapi" mpilib='openmpi'>
       <command name="--force purge"></command>
       <command name="load">StdEnv</command>
+      <command name="load">git/2.41.0-GCCcore-12.3.0-nodocs</command>
       <command name="use">/cluster/shared/noresm/eb_mods/modules/all</command>
       <command name="load">ESMF/8.4.2-iomkl-2022a-ParallelIO-2.5.10</command>
       <command name="load">Python/3.11.3-GCCcore-12.3.0</command>
       <command name="load">CMake/3.26.3-GCCcore-12.3.0</command>
       <command name="load">ParMETIS/4.0.3-iompi-2022a</command>
-      <command name="load">git/2.38.1-GCCcore-12.2.0-nodocs</command>
+      <command name="load">XML-LibXML/2.0209-GCCcore-12.3.0</command>
     </modules>
     <modules compiler="intel" mpilib="openmpi">
       <command name="--force purge"></command>
       <command name="load">StdEnv</command>
+      <command name="load">git/2.41.0-GCCcore-12.3.0-nodocs</command>
       <command name="use">/cluster/shared/noresm/eb_mods/modules/all</command>
       <command name="load">ESMF/8.4.1-iomkl-2021b-ParallelIO-2.5.10</command>
       <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
       <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
       <command name="load">ParMETIS/4.0.3-iompi-2021b</command>
-      <command name="load">git/2.38.1-GCCcore-12.2.0-nodocs</command>
+      <command name="load">XML-LibXML/2.0209-GCCcore-12.3.0</command>
     </modules>
     <modules compiler="intel" mpilib="impi">
       <command name="--force purge"></command>
       <command name="load">StdEnv</command>
+      <command name="load">git/2.41.0-GCCcore-12.3.0-nodocs</command>
       <command name="use">/cluster/shared/noresm/eb_mods/modules/all</command>
       <command name="load">ESMF/8.4.1-intel-2021b-ParallelIO-2.5.10</command>
       <command name="load">CMake/3.21.1-GCCcore-11.2.0</command>
       <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
       <command name="load">ParMETIS/4.0.3-iimpi-2021b</command>
-      <command name="load">git/2.38.1-GCCcore-12.2.0-nodocs</command>
+      <command name="load">XML-LibXML/2.0209-GCCcore-12.3.0</command>
     </modules>
   </module_system>
   <environment_variables>


### PR DESCRIPTION
The new addition is needed for ctsm namelist generation to work. Tested that with this change the model N1850 was able to build and run. 