### PR TITLE
Update ESMF to 8.6.1 and dependecies

### DIFF
--- a/machines/betzy/config_machines.xml
+++ b/machines/betzy/config_machines.xml
@@ -8,7 +8,7 @@
   <DIN_LOC_ROOT_CLMFORC>/cluster/shared/noresm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>/cluster/work/users/$USER/archive/$CASE</DOUT_S_ROOT>
   <BASELINE_ROOT> /cluster/shared/noresm/noresm_baselines</BASELINE_ROOT>
-  <CCSM_CPRNC>/cluster/shared/noresm/tools/cprnc-iompi-2022a/bin/cprnc</CCSM_CPRNC>
+  <CCSM_CPRNC>/cluster/shared/noresm/tools/cprnc-iompi-2023b/bin/cprnc</CCSM_CPRNC>
   <GMAKE_J>8</GMAKE_J>
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>noresmCommunity</SUPPORTED_BY>
@@ -33,14 +33,13 @@
     <modules compiler="intel" mpilib='openmpi'>
       <command name="--force purge"></command>
       <command name="load">StdEnv</command>
-      <command name="use">/cluster/shared/noresm/eb_mods/modules/all</command>
-      <command name="load">ESMF/8.4.2-iomkl-2022a-ParallelIO-2.5.10</command>
-      <command name="load">Python/3.11.3-GCCcore-12.3.0</command>
-      <command name="load">CMake/3.26.3-GCCcore-12.3.0</command>
-      <command name="load">ParMETIS/4.0.3-iompi-2022a</command>
-      <command name="load">git/2.41.0-GCCcore-12.3.0-nodocs</command>
-      <command name="load">XML-LibXML/2.0209-GCCcore-12.3.0</command>
-      <command name="load">hpcx/2.20</command>
+      <command name="use">/cluster/shared/noresm/eb_mods_2023b/modules/all/</command>
+      <command name="load">git/2.42.0-GCCcore-13.2.0</command>
+      <command name="load">ESMF/8.6.1-iomkl-2023b-ParallelIO-2.6.3</command>
+      <command name="load">ParMETIS/4.0.3-iompi-2023b</command>
+      <command name="load">Python/3.11.5-GCCcore-13.2.0</command>
+      <command name="load">CMake/3.27.6-GCCcore-13.2.0</command>
+      <command name="load">XML-LibXML/2.0210-GCCcore-13.2.0</command>
     </modules>
   </module_system>
   <environment_variables>


### PR DESCRIPTION
Updated ESMF from 8.4.2 to 8.6.1 and PIO to 2.6.3 (includes a bug fix for 2.6.2).
All dependecies are built with iomkl-iomi/2023b, modules do not have internal dependency conflicts.


Tested with `noresm2_5_alpha08b`:
```
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio CREATE_NEWCASE
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio XML
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio SETUP
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio SHAREDLIB_BUILD time=366
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio MODEL_BUILD time=496
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio SUBMIT
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio RUN time=1064
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio COMPARE_base_rest
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio MEMLEAK insufficient data for memleak test
PASS ERS_Ld5.ne30pg3_tn14.N1850fates-sp.betzy_intel.allactive-defaultio SHORT_TERM_ARCHIVER
```