### PR TITLE
add cpus-per-task on preproc to not get oom for single point ctsm runs

### DIFF
--- a/machines/betzy/config_batch.xml
+++ b/machines/betzy/config_batch.xml
@@ -23,7 +23,7 @@
   </directives>
     <queues>
       <queue walltimedef="00:59:00" walltimemax="96:00:00" nodemin="4" nodemax="1024" default="true">normal</queue>
-      <queue walltimedef="00:20:00"  walltimemax="23:59:00" jobmin="1" jobmax="32" default="true">preproc</queue>
+      <queue walltimedef="00:20:00"  walltimemax="23:59:00" jobmin="1" default="true">preproc</queue>
       <queue walltimedef="00:59:00" walltimemax="00:59:00" nodemin="1" nodemax="4" >devel</queue>
     </queues>
 </batch_system>

--- a/machines/betzy/config_batch.xml
+++ b/machines/betzy/config_batch.xml
@@ -19,10 +19,11 @@
   <directives queue = "preproc">
     <directive> --partition=preproc</directive>
     <directive> --mem-per-cpu=1900M</directive>
+    <directive> --cpus-per-task=4</directive>
   </directives>
     <queues>
-      <queue walltimedef="00:59:00" walltimemax="48:00:00" nodemin="4" nodemax="1024" default="true">normal</queue>
-      <queue walltimedef="00:59:00" walltimemax="23:59:00" jobmin="1" jobmax="127" >preproc</queue>
+      <queue walltimedef="00:59:00" walltimemax="96:00:00" nodemin="4" nodemax="1024" default="true">normal</queue>
+      <queue walltimedef="00:20:00"  walltimemax="23:59:00" jobmin="1" jobmax="32" default="true">preproc</queue>
       <queue walltimedef="00:59:00" walltimemax="00:59:00" nodemin="1" nodemax="4" >devel</queue>
     </queues>
 </batch_system>


### PR DESCRIPTION
More than 2G of memory is needed for some configurations of CTSM when running single point. Since we can not checkout more memory for 1 cpu on preproc due to resubmit to normal queue issue, increase the number of cpus-per-task on the preproc queue.