### PR TITLE
Add Univ. Toronto server

### DIFF
--- a/config_inputdata.xml
+++ b/config_inputdata.xml
@@ -21,6 +21,11 @@
 
   <server>
     <protocol>wget</protocol>
+    <address>https://redoak.cs.toronto.edu/twitcher/ows/proxy/thredds/fileServer/datasets/CESM/inputdata/</address>
+  </server>
+
+  <server>
+    <protocol>wget</protocol>
     <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata/</address>
     <user>anonymous</user>
     <password>user@example.edu</password>


### PR DESCRIPTION
Steve Easterbrook at the University of Toronto has created a mirror of the CESM inputdata repository. This PR adds the new mirror as a bacup server.