### PR TITLE
Add model grid alias ne30pg3_tn05

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -363,7 +363,7 @@
     <grid name="glc">ais8:gris4</grid>
     <mask>tnx1v4</mask>
   </model_grid>
-  <model_grid alias="ne30pg3_tn05">
+  <model_grid alias="ne30pg3_tn05" compset="BLOM">
     <grid name="atm">ne30np4.pg3</grid>
     <grid name="lnd">ne30np4.pg3</grid>
     <grid name="ocnice">tnx0.5v1</grid>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -363,6 +363,12 @@
     <grid name="glc">ais8:gris4</grid>
     <mask>tnx1v4</mask>
   </model_grid>
+  <model_grid alias="ne30pg3_tn05">
+    <grid name="atm">ne30np4.pg3</grid>
+    <grid name="lnd">ne30np4.pg3</grid>
+    <grid name="ocnice">tnx0.5v1</grid>
+    <mask>tnx0.5v1</mask>
+  </model_grid>
   <model_grid alias="ne30_ne30_mg17" not_compset="BLOM">
     <grid name="atm">ne30np4</grid>
     <grid name="lnd">ne30np4</grid>


### PR DESCRIPTION
Model grid alias ne30pg3_tn05 uses ne30np4.pg3 for atm/lnd and tnx0.5v1 for ocnice.