### PR TITLE
Include ROF2OCN mapping files for all BLOM supported resolutions

### DIFF
--- a/maps_nuopc.xml
+++ b/maps_nuopc.xml
@@ -47,6 +47,10 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx3v7_nnsm_e1000r500_180430.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx3v7_nnsm_e1000r500_180430.nc</map>
     </gridmap>
+    <gridmap rof_grid="r05" ocn_grid="tnx2v1" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tnx2v1_e1000r300_130206.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tnx2v1_e1000r300_130206.nc</map>
+    </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tnx1v4" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tnx1v4_e1000r300_170609.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tnx1v4_e1000r300_170609.nc</map>

--- a/maps_nuopc.xml
+++ b/maps_nuopc.xml
@@ -32,6 +32,10 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tx0.1v3_nnsm_e1000r200_170914.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tx0.1v3_nnsm_e1000r200_170914.nc</map>
     </gridmap>
+    <gridmap rof_grid="rx1" ocn_grid="tnx2v1" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tnx2v1_e1000r300_130206.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tnx2v1_e1000r300_130206.nc</map>
+    </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tnx1v4" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tnx1v4_e1000r300_170606.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tnx1v4_e1000r300_170606.nc</map>
@@ -39,6 +43,10 @@
     <gridmap rof_grid="rx1" ocn_grid="tnx0.5v1" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tnx0.5v1_e300r100_20240702.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tnx0.5v1_e300r100_20240702.nc</map>
+    </gridmap>
+    <gridmap rof_grid="rx1" ocn_grid="tnx0.25v4" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tnx0.25v4_e300r100_170629.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tnx0.25v4_e300r100_170629.nc</map>
     </gridmap>
 
     <!-- r05 river grid -->
@@ -58,6 +66,10 @@
     <gridmap rof_grid="r05" ocn_grid="tnx0.5v1" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tnx0.5v1_e300r100_20240702.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tnx0.5v1_e300r100_20240702.nc</map>
+    </gridmap>
+    <gridmap rof_grid="r05" ocn_grid="tnx0.25v4" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tnx0.25v4_e300r100_170629.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tnx0.25v4_e300r100_170629.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx1v1" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx1v1_e1000r500_161214.nc</map>

--- a/maps_nuopc.xml
+++ b/maps_nuopc.xml
@@ -89,6 +89,7 @@
     </gridmap>
 
     <!-- JRA025 river grid -->
+    <!-- ROF2OCN mapping file missing for rof_grid="JRA025" and ocn_grid="tnx2v1","tnx0.25v4" and "tnx0.125v4" -->
 
     <gridmap rof_grid="JRA025" ocn_grid="tx0.1v2" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v2_e333r100_170619.nc</map>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -145,6 +145,7 @@
   </model_grid>
 
   <!-- TL319 datm JRA grid -->
+  <!-- ROF2OCN mapping file missing for TL319_tn21, TL319_tn025 and TL319_tn0125 -->
 
   <model_grid alias="TL319_tn21" not_compset="_CAM" compset="DROF%JRA|_SROF">
     <grid name="atm">TL319</grid>
@@ -172,7 +173,7 @@
     <grid name="lnd">TL319</grid>
     <grid name="rof">JRA025</grid>
     <grid name="ocnice">tnx0.25v4</grid>
-    <mask>tn0.25v4</mask>
+    <mask>tnx0.25v4</mask>
   </model_grid>
   <model_grid alias="TL319_tn0125" not_compset="_CAM" compset="DROF%JRA|_SROF">
     <grid name="atm">TL319</grid>


### PR DESCRIPTION
This PR enables ROF2OCN mapping with the `tnx2v1` ocean and sea ice grid.

Required mapping files:
- [x] r1->tnx2v1
- [x] r1->tnx0.25v4
- [x] r05->tnx2v1
- [x] r05->tnx0.25v4

TBD : JRA025 remapping files are currently not available.

Testing:
- [x] Run NOINYOC compset with 2 degree ocean

@TomasTorsvik - this PR name should be changed to be "Include ROF2OCN mapping files for all BLOM supported resolutions"