### PR TITLE
Add DGLC default grids

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -514,6 +514,21 @@
   </domain>
 
   <!-- ======================================================== -->
+  <!-- DGLC domains -->
+  <!-- ======================================================== -->
+
+  <domain name="gris4d">
+    <nx>416</nx> <ny>704</ny>
+    <mesh>$DIN_LOC_ROOT/share/meshes/greenland_4km_epsg3413_c170414_ESMFmesh_c20190729.nc</mesh>
+    <desc>4-km Greenland grid, for use with DGLC</desc>
+  </domain>
+  <domain name="ais8d">
+    <nx>704</nx> <ny>576</ny>
+    <mesh>$DIN_LOC_ROOT/share/meshes/antarctica_8km_epsg3031_ESMFmesh_c210621.nc</mesh>
+    <desc>8-km Antarctica grid for use with DGLC</desc>
+  </domain>
+
+  <!-- ======================================================== -->
   <!-- WW3 domains-->
   <!-- ======================================================== -->
 

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -19,7 +19,7 @@
     <grid name="rof"       compset="XROF"        >r05</grid>
 
     <grid name="glc"       compset="CISM2"       >gris4</grid>
-    <grid name="glc"       compset="DGLC"        >gris4</grid>
+    <grid name="glc"       compset="DGLC"        >gris4d</grid>
     <grid name="glc"       compset="XGLC"        >gris4</grid>
 
     <grid name="wav"       compset="WW3"         >wtnx1v4</grid>
@@ -388,7 +388,7 @@
     <grid name="ocnice">tnx0.5v1</grid>
     <mask>tnx0.5v1</mask>
   </model_grid>
-    
+
   <model_grid alias="ne30_ne30_mg17" not_compset="BLOM">
     <grid name="atm">ne30np4</grid>
     <grid name="lnd">ne30np4</grid>


### PR DESCRIPTION
Restore the previous versions of gris4 and ais8 as DGLC grids, gris4d and ais8d.

The recent change to the `gris4` grid seems to cause restart issues for fully-coupled NorESM compsets. This PR brings back. the old `gris4` and `ais8` grids but with new names so that both can exist. The new `gris4d` grid is made the default for NorESM compsets.