### PR TITLE
Add ne3pg3 grid for CAM NF compsets (DOCN)

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -234,20 +234,20 @@
 
   <!-- f09 finite volume atm grid -->
 
-  <model_grid alias="f09_g17" not_compset="BLOM">
+  <model_grid alias="f09_g17" not_compset="_BLOM">
     <grid name="atm">0.9x1.25</grid>
     <grid name="lnd">0.9x1.25</grid>
     <grid name="ocnice">gx1v7</grid>
     <mask>gx1v7</mask>
   </model_grid>
-  <model_grid alias="f09_f09_mg17" not_compset="BLOM">
+  <model_grid alias="f09_f09_mg17" not_compset="_BLOM">
     <!-- Needed for aux_cdeps_noresm test suite -->
     <grid name="atm">0.9x1.25</grid>
     <grid name="lnd">0.9x1.25</grid>
     <grid name="ocnice">0.9x1.25</grid>
     <mask>gx1v7</mask>
   </model_grid>
-  <model_grid alias="f09_f09_mtn14" not_compset="BLOM">
+  <model_grid alias="f09_f09_mtn14" not_compset="_BLOM">
     <grid name="atm">0.9x1.25</grid>
     <grid name="lnd">0.9x1.25</grid>
     <grid name="ocnice">0.9x1.25</grid>
@@ -274,7 +274,7 @@
     <grid name="ocnice">tnx1v4</grid>
     <mask>tnx1v4</mask>
   </model_grid>
-  <model_grid alias="f19_g17" not_compset="BLOM">
+  <model_grid alias="f19_g17" not_compset="_BLOM">
     <grid name="atm">1.9x2.5</grid>
     <grid name="lnd">1.9x2.5</grid>
     <grid name="ocnice">gx1v7</grid>
@@ -320,13 +320,13 @@
     <grid name="ocnice">ne3np4.pg3</grid>
     <mask>gx3v7</mask>
   </model_grid>
-  <model_grid alias="ne5_ne5_mg37" not_compset="BLOM">
+  <model_grid alias="ne5_ne5_mg37" not_compset="_BLOM">
     <grid name="atm">ne5np4</grid>
     <grid name="lnd">ne5np4</grid>
     <grid name="ocnice">ne5np4</grid>
     <mask>gx3v7</mask>
   </model_grid>
-  <model_grid alias="ne16_ne16_tn14" not_compset="BLOM">
+  <model_grid alias="ne16_ne16_tn14" not_compset="_BLOM">
     <grid name="atm">ne16np4</grid>
     <grid name="lnd">ne16np4</grid>
     <grid name="ocnice">ne16np4</grid>
@@ -389,7 +389,7 @@
     <mask>tnx0.5v1</mask>
   </model_grid>
 
-  <model_grid alias="ne30_ne30_mg17" not_compset="BLOM">
+  <model_grid alias="ne30_ne30_mg17" not_compset="_BLOM">
     <grid name="atm">ne30np4</grid>
     <grid name="lnd">ne30np4</grid>
     <grid name="ocnice">ne30np4</grid>
@@ -415,7 +415,7 @@
     <grid name="ocnice">tx0.1v2</grid>
     <mask>tx0.1v2</mask>
   </model_grid>
-  <model_grid alias="ne120_ne120_mg17" not_compset="BLOM">
+  <model_grid alias="ne120_ne120_mg17" not_compset="_BLOM">
     <grid name="atm">ne120np4</grid>
     <grid name="lnd">ne120np4</grid>
     <grid name="ocnice">ne120np4</grid>
@@ -432,42 +432,42 @@
 
   <!--  spectral element grids with 3x3 FVM physics grid -->
 
-  <model_grid alias="ne3pg3_ne3pg3_mtn14" not_compset="BLOM">
+  <model_grid alias="ne3pg3_ne3pg3_mtn14" not_compset="_BLOM">
     <grid name="atm">ne3np4.pg3</grid>
     <grid name="lnd">ne3np4.pg3</grid>
     <grid name="ocnice">ne3np4.pg3</grid>
     <mask>tnx1v4</mask>
   </model_grid>
 
-  <model_grid alias="ne5pg3_ne5pg3_mtn14" not_compset="BLOM">
+  <model_grid alias="ne5pg3_ne5pg3_mtn14" not_compset="_BLOM">
     <grid name="atm">ne5np4.pg3</grid>
     <grid name="lnd">ne5np4.pg3</grid>
     <grid name="ocnice">ne5np4.pg3</grid>
     <mask>tnx1v4</mask>
   </model_grid>
 
-  <model_grid alias="ne16pg3_ne16pg3_mtn14" not_compset="BLOM">
+  <model_grid alias="ne16pg3_ne16pg3_mtn14" not_compset="_BLOM">
     <grid name="atm">ne16np4.pg3</grid>
     <grid name="lnd">ne16np4.pg3</grid>
     <grid name="ocnice">ne16np4.pg3</grid>
     <mask>tnx1v4</mask>
   </model_grid>
 
-  <model_grid alias="ne30pg3_ne30pg3_mtn14" not_compset="BLOM">
+  <model_grid alias="ne30pg3_ne30pg3_mtn14" not_compset="_BLOM">
     <grid name="atm">ne30np4.pg3</grid>
     <grid name="lnd">ne30np4.pg3</grid>
     <grid name="ocnice">ne30np4.pg3</grid>
     <mask>tnx1v4</mask>
   </model_grid>
 
-  <model_grid alias="ne60pg3_ne60pg3_mtn14" not_compset="BLOM">
+  <model_grid alias="ne60pg3_ne60pg3_mtn14" not_compset="_BLOM">
     <grid name="atm">ne60np4.pg3</grid>
     <grid name="lnd">ne60np4.pg3</grid>
     <grid name="ocnice">ne60np4.pg3</grid>
     <mask>tnx1v4</mask>
   </model_grid>
 
-  <model_grid alias="ne120pg3_ne120pg3_mtn14" not_compset="BLOM">
+  <model_grid alias="ne120pg3_ne120pg3_mtn14" not_compset="_BLOM">
     <grid name="atm">ne120np4.pg3</grid>
     <grid name="lnd">ne120np4.pg3</grid>
     <grid name="ocnice">ne120np4.pg3</grid>
@@ -483,13 +483,13 @@
 
   <!-- VR-CESM grids with CAM-SE -->
 
-  <model_grid alias="ne0TESTONLYne5x4_ne0TESTONLYne5x4_mg37" not_compset="BLOM">
+  <model_grid alias="ne0TESTONLYne5x4_ne0TESTONLYne5x4_mg37" not_compset="_BLOM">
     <grid name="atm">ne0np4TESTONLY.ne5x4</grid>
     <grid name="lnd">ne0np4TESTONLY.ne5x4</grid>
     <grid name="ocnice">ne0np4TESTONLY.ne5x4</grid>
     <mask>gx3v7</mask>
   </model_grid>
-  <model_grid alias="ne0ARCTICne30x4_ne0ARCTICne30x4_mt12" not_compset="BLOM">
+  <model_grid alias="ne0ARCTICne30x4_ne0ARCTICne30x4_mt12" not_compset="_BLOM">
     <grid name="atm">ne0np4.ARCTIC.ne30x4</grid>
     <grid name="lnd">ne0np4.ARCTIC.ne30x4</grid>
     <grid name="ocnice">ne0np4.ARCTIC.ne30x4</grid>
@@ -501,13 +501,13 @@
     <grid name="ocnice">tnx1v4</grid>
     <mask>tnx1v4</mask>
   </model_grid>
-  <model_grid alias="ne0ARCTICne30x4_t12" not_compset="BLOM">
+  <model_grid alias="ne0ARCTICne30x4_t12" not_compset="_BLOM">
     <grid name="atm">ne0np4.ARCTIC.ne30x4</grid>
     <grid name="lnd">ne0np4.ARCTIC.ne30x4</grid>
     <grid name="ocnice">tx0.1v2</grid>
     <mask>tx0.1v2</mask>
   </model_grid>
-  <model_grid alias="ne0ARCTICne30x4_ne0ARCTICne30x4_mg17" not_compset="BLOM">
+  <model_grid alias="ne0ARCTICne30x4_ne0ARCTICne30x4_mg17" not_compset="_BLOM">
     <grid name="atm">ne0np4.ARCTIC.ne30x4</grid>
     <grid name="lnd">ne0np4.ARCTIC.ne30x4</grid>
     <grid name="ocnice">ne0np4.ARCTIC.ne30x4</grid>
@@ -519,7 +519,7 @@
     <grid name="ocnice">gx1v7</grid>
     <mask>gx1v7</mask>
   </model_grid>
-  <model_grid alias="ne0ARCTICGRISne30x8_ne0ARCTICGRISne30x8_mt12" not_compset="BLOM">
+  <model_grid alias="ne0ARCTICGRISne30x8_ne0ARCTICGRISne30x8_mt12" not_compset="_BLOM">
     <grid name="atm">ne0np4.ARCTICGRIS.ne30x8</grid>
     <grid name="lnd">ne0np4.ARCTICGRIS.ne30x8</grid>
     <grid name="ocnice">ne0np4.ARCTICGRIS.ne30x8</grid>
@@ -528,19 +528,19 @@
 
   <!-- MPAS-A grids -->
 
-  <model_grid alias="mpasa480_mpasa480_mg17" not_compset="BLOM">
+  <model_grid alias="mpasa480_mpasa480_mg17" not_compset="_BLOM">
     <grid name="atm">mpasa480</grid>
     <grid name="lnd">mpasa480</grid>
     <grid name="ocnice">mpasa480</grid>
     <mask>gx1v7</mask>
   </model_grid>
-  <model_grid alias="mpasa240_mpasa240_mg17" not_compset="BLOM">
+  <model_grid alias="mpasa240_mpasa240_mg17" not_compset="_BLOM">
     <grid name="atm">mpasa240</grid>
     <grid name="lnd">mpasa240</grid>
     <grid name="ocnice">mpasa240</grid>
     <mask>gx1v7</mask>
   </model_grid>
-  <model_grid alias="mpasa120_mpasa120_mg17" not_compset="BLOM">
+  <model_grid alias="mpasa120_mpasa120_mg17" not_compset="_BLOM">
     <grid name="atm">mpasa120</grid>
     <grid name="lnd">mpasa120</grid>
     <grid name="ocnice">mpasa120</grid>
@@ -576,7 +576,7 @@
   <!-- Section: model grids with land ice -->
   <!-- ======================================== -->
 
-  <model_grid alias="T31_g37_gris4" not_compset="BLOM">
+  <model_grid alias="T31_g37_gris4" not_compset="_BLOM">
     <grid name="atm">T31</grid>
     <grid name="lnd">T31</grid>
     <grid name="ocnice">gx3v7</grid>
@@ -597,14 +597,14 @@
     <grid name="glc">gris4</grid>
     <mask>gx1v7</mask>
   </model_grid>
-  <model_grid alias="f10_f10_ais8_mg37" not_compset="BLOM">
+  <model_grid alias="f10_f10_ais8_mg37" not_compset="_BLOM">
     <grid name="atm">10x15</grid>
     <grid name="lnd">10x15</grid>
     <grid name="ocnice">10x15</grid>
     <grid name="glc">ais8</grid>
     <mask>gx3v7</mask>
   </model_grid>
-  <model_grid alias="f10_f10_ais8gris4_mg37" not_compset="BLOM">
+  <model_grid alias="f10_f10_ais8gris4_mg37" not_compset="_BLOM">
     <grid name="atm">10x15</grid>
     <grid name="lnd">10x15</grid>
     <grid name="ocnice">10x15</grid>
@@ -653,14 +653,14 @@
     <grid name="ocnice">tnx1v4</grid>
     <mask>tnx1v4</mask>
   </model_grid>
-  <model_grid alias="f19_f19_ais8_mtn14" not_compset="BLOM">
+  <model_grid alias="f19_f19_ais8_mtn14" not_compset="_BLOM">
     <grid name="atm">1.9x2.5</grid>
     <grid name="lnd">1.9x2.5</grid>
     <grid name="glc">ais8</grid>
     <grid name="ocnice">tnx1v4</grid>
     <mask>tnx1v4</mask>
   </model_grid>
-  <model_grid alias="f19_f19_ais8gris4_mtn14" not_compset="BLOM">
+  <model_grid alias="f19_f19_ais8gris4_mtn14" not_compset="_BLOM">
     <grid name="atm">1.9x2.5</grid>
     <grid name="lnd">1.9x2.5</grid>
     <grid name="glc">ais8:gris4</grid>
@@ -714,7 +714,7 @@
     <grid name="wav">w025</grid>
     <mask>tnx1v4</mask>
   </model_grid>
-  <model_grid alias="f19_g17_wg17" not_compset="BLOM" >
+  <model_grid alias="f19_g17_wg17" not_compset="_BLOM" >
     <grid name="atm">1.9x2.5</grid>
     <grid name="lnd">1.9x2.5</grid>
     <grid name="ocnice">gx1v7</grid>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -432,11 +432,18 @@
 
   <!--  spectral element grids with 3x3 FVM physics grid -->
 
-  <model_grid alias="ne5pg3_ne5pg3_mg37" not_compset="BLOM">
+  <model_grid alias="ne3pg3_ne3pg3_mtn14" not_compset="BLOM">
+    <grid name="atm">ne3np4.pg3</grid>
+    <grid name="lnd">ne3np4.pg3</grid>
+    <grid name="ocnice">ne3np4.pg3</grid>
+    <mask>tnx1v4</mask>
+  </model_grid>
+
+  <model_grid alias="ne5pg3_ne5pg3_mtn14" not_compset="BLOM">
     <grid name="atm">ne5np4.pg3</grid>
     <grid name="lnd">ne5np4.pg3</grid>
     <grid name="ocnice">ne5np4.pg3</grid>
-    <mask>gx3v7</mask>
+    <mask>tnx1v4</mask>
   </model_grid>
 
   <model_grid alias="ne16pg3_ne16pg3_mtn14" not_compset="BLOM">


### PR DESCRIPTION
Also modify ne5pg3 grid to use BLOM mask.
This PR enables use of the ne3pg3 resolution (approx 10 degree) for NF compsets.