### PR TITLE
new default grid for DGLC using both Greenland and Antarctica

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -19,7 +19,7 @@
     <grid name="rof"       compset="XROF"        >r05</grid>
 
     <grid name="glc"       compset="CISM2"       >gris4</grid>
-    <grid name="glc"       compset="DGLC"        >ais8d:gris4d</grid>
+    <grid name="glc"       compset="DGLC"        >ais8:gris4</grid>
     <grid name="glc"       compset="XGLC"        >gris4</grid>
 
     <grid name="wav"       compset="WW3"         >wtnx1v4</grid>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -19,7 +19,7 @@
     <grid name="rof"       compset="XROF"        >r05</grid>
 
     <grid name="glc"       compset="CISM2"       >gris4</grid>
-    <grid name="glc"       compset="DGLC"        >ais8:gris4d</grid>
+    <grid name="glc"       compset="DGLC"        >ais8d:gris4d</grid>
     <grid name="glc"       compset="XGLC"        >gris4</grid>
 
     <grid name="wav"       compset="WW3"         >wtnx1v4</grid>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -19,7 +19,7 @@
     <grid name="rof"       compset="XROF"        >r05</grid>
 
     <grid name="glc"       compset="CISM2"       >gris4</grid>
-    <grid name="glc"       compset="DGLC"        >gris4d</grid>
+    <grid name="glc"       compset="DGLC"        >ais8:gris4d</grid>
     <grid name="glc"       compset="XGLC"        >gris4</grid>
 
     <grid name="wav"       compset="WW3"         >wtnx1v4</grid>


### PR DESCRIPTION
This change is based on a request from @mpetrini-norce:
This was already mentioned in a Github issue (https://github.com/NorESMhub/CTSM/issues/158#issuecomment-3436748968) that it would make sense to have in the standard DGLC%NOEVOLVE compset the Antarctic domain as well (g%ais8:gris4). This enables us to quickly diagnose SMB from cplhist files - there are no changes other than domains and mesh files, see below:

```
GLC_DOMAIN_MESH=$DIN_LOC_ROOT/share/meshes/antarctica_8km_epsg3031_ESMFmesh_c20250303.nc:$DIN_LOC_ROOT/share/meshes/greenland_4km_epsg3413_ESMFmesh_c20250303.nc 
user_nl_dglc 
datamode = "noevolve” 
model_datafiles_list = "/cluster/shared/noresm/inputdata/glc/cism/Antarctica/antarctica_8km_epsg3031_c20250403.nc:/cluster/shared/noresm/inputdata/glc/cism/Greenland/[greenland_4km_epsg3413_c20250227.nc](http://greenland_4km_epsg3413_c20250227.nc/)" model_internal_gridsize = 8000, 4000 
model_meshfiles_list = "/cluster/shared/noresm/inputdata/share/meshes/antarctica_8km_epsg3031_ESMFmesh_c20250303.nc:/cluster/shared/noresm/inputdata/share/meshes/greenland_4km_epsg3413_ESMFmesh_c20250303.nc” 
nx_global = 761, 421
```
This PR must accompany https://github.com/NorESMhub/CDEPS/pull/34. See that PR for a testing summary.

