### PR TITLE
Fix Olivia xml settings

### DIFF
--- a/machines/olivia/config_batch.xml
+++ b/machines/olivia/config_batch.xml
@@ -8,11 +8,11 @@
     <directive> --ntasks={{ total_tasks }}</directive>
     <directive> --export=ALL</directive>
     <directive> --network=single_node_vni</directive>
+    <directive> --mem={{ mem_per_node }}G</directive>
   </directives>
   <!-- default job type, meant for CPU-only jobs needing less than a whole node (< 256 CPUs) -->
   <directives queue = "small">
     <directive> --partition=small</directive>
-    <directive> --mem-per-cpu=2700M</directive>
   </directives>
   <!-- meant for larger CPU-only jobs, needing at least one node (> 256 CPUs) -->
   <directives queue = "large">
@@ -21,7 +21,6 @@
   <!-- maximum walltime 2 hours -->
   <directives queue = "devel">
     <directive> --partition=small</directive>
-    <directive> --mem-per-cpu=2700M</directive>
     <directive> --qos=devel</directive>
   </directives>
     <queues>

--- a/machines/olivia/config_machines.xml
+++ b/machines/olivia/config_machines.xml
@@ -2,17 +2,20 @@
   <DESC>HPE Cray Supercomputing EX, CPU AMD Epyc Turin, with 256 CPU cores per node, os is Linux, batch system is SLURM</DESC>
   <OS>LINUX</OS>
   <COMPILERS>intel,gnu</COMPILERS>
-  <MPILIBS>oneapi,openmpi</MPILIBS>
-  <CIME_OUTPUT_ROOT>/cluster/work/projects/nn9560k/$USER/noresm/</CIME_OUTPUT_ROOT>
+  <MPILIBS compiler="intel" >oneapi,openmpi</MPILIBS>
+  <MPILIBS compiler="gnu">openmpi</MPILIBS>
+  <CIME_OUTPUT_ROOT>/cluster/work/projects/$PROJECT/$USER/noresm/</CIME_OUTPUT_ROOT>
   <DIN_LOC_ROOT>/cluster/work/projects/nn9560k/inputdata/</DIN_LOC_ROOT>
   <DIN_LOC_ROOT_CLMFORC>/cluster/work/projects/nn9560k/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-  <DOUT_S_ROOT>/cluster/work/projects/nn9560k/$USER/archive/$CASE</DOUT_S_ROOT>
+  <DOUT_S_ROOT>/cluster/work/projects/$PROJECT/$USER/archive/$CASE</DOUT_S_ROOT>
   <BASELINE_ROOT> /cluster/work/projects/nn9560k/noresm_baselines</BASELINE_ROOT>
   <CCSM_CPRNC>$ENV{CPRNC_PREF}/bin/cprnc</CCSM_CPRNC>
   <GMAKE_J>8</GMAKE_J>
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>noresmCommunity</SUPPORTED_BY>
   <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
+  <MEM_PER_TASK>8</MEM_PER_TASK>
+  <MAX_MEM_PER_NODE>740</MAX_MEM_PER_NODE>
   <MAX_MPITASKS_PER_NODE>256</MAX_MPITASKS_PER_NODE>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <mpirun mpilib="openmpi">
@@ -66,6 +69,9 @@
   </environment_variables>
   <environment_variables compiler="intel">
     <env name="CPRNC_PREF">/cluster/shared/noresm/tools/iimkl24a</env>
+  </environment_variables>
+  <environment_variables compiler="gnu">
+    <env name="CPRNC_PREF">/cluster/shared/noresm/tools/gnuopenmpi</env>
   </environment_variables>
   <resource_limits>
     <resource name="RLIMIT_STACK">-1</resource>

--- a/machines/template.compress
+++ b/machines/template.compress
@@ -2,7 +2,7 @@
 
 # Batch system directives
 {{ batchdirectives }}
-#SBATCH  --mem-per-cpu=10000M
+
 
 machine=`./xmlquery --value MACH`
 echo $machine


### PR DESCRIPTION
Make GNU work.
Use MEM_PER_TASK properly.
Also, use PROJECT variable, so ppl without access to nn9560k can create cases.

fixes #82 