### PR TITLE
update model_grid_aliases

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -723,6 +723,11 @@
     <grid name="wav">ww3a</grid>
     <!-- only used for ADWAV testing -->
   </model_grid>
+  <model_grid alias="TL319_ww3a" not_compset="_CAM">
+     <grid name="atm">TL319</grid>
+     <grid name="wav">ww3a</grid>
+     <mask>tnx1v4</mask>
+  </model_grid>
   <model_grid alias="TL319_wtn14" not_compset="_CAM">
     <grid name="atm">TL319</grid>
     <grid name="wav">wtnx1v4</grid>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -349,31 +349,38 @@
     <grid name="ocnice">ne5np4</grid>
     <mask>gx3v7</mask>
   </model_grid>
-  <model_grid alias="ne16_ne16_tn14" not_compset="_BLOM">
-    <grid name="atm">ne16np4</grid>
-    <grid name="lnd">ne16np4</grid>
-    <grid name="ocnice">ne16np4</grid>
-    <mask>tnx1v4</mask>
-  </model_grid>
 
-  <model_grid alias="ne16_tn14">
-    <grid name="atm">ne16np4</grid>
-    <grid name="lnd">ne16np4</grid>
-    <grid name="ocnice">tnx1v4</grid>
-    <mask>tnx1v4</mask>
-  </model_grid>
-  <model_grid alias="ne30_tn14">
-    <grid name="atm">ne30np4</grid>
-    <grid name="lnd">ne30np4</grid>
-    <grid name="ocnice">tnx1v4</grid>
-    <mask>tnx1v4</mask>
-  </model_grid>
   <model_grid alias="ne16pg3_tn14">
     <grid name="atm">ne16np4.pg3</grid>
     <grid name="lnd">ne16np4.pg3</grid>
     <grid name="ocnice">tnx1v4</grid>
     <mask>tnx1v4</mask>
   </model_grid>
+
+  <model_grid alias="ne16pg3_tn14_ais8gris4" compset="CISM2%AIS-EVOLVE%GRIS-EVOLVE">
+    <grid name="atm">ne16np4.pg3</grid>
+    <grid name="lnd">ne16np4.pg3</grid>
+    <grid name="ocnice">tnx1v4</grid>
+    <grid name="glc">ais8:gris4</grid>
+    <mask>tnx1v4</mask>
+  </model_grid>
+
+  <model_grid alias="ne16pg3_tn14_gris4" compset="CISM2%GRIS-EVOLVE">
+    <grid name="atm">ne16np4.pg3</grid>
+    <grid name="lnd">ne16np4.pg3</grid>
+    <grid name="ocnice">tnx1v4</grid>
+    <grid name="glc">gris4</grid>
+    <mask>tnx1v4</mask>
+  </model_grid>
+
+  <model_grid alias="ne16pg3_tn14_ais8" compset="CISM2%AIS-EVOLVE">
+    <grid name="atm">ne16np4.pg3</grid>
+    <grid name="lnd">ne16np4.pg3</grid>
+    <grid name="ocnice">tnx1v4</grid>
+    <grid name="glc">ais8</grid>
+    <mask>tnx1v4</mask>
+  </model_grid>
+
   <model_grid alias="ne30pg3_tn14">
     <grid name="atm">ne30np4.pg3</grid>
     <grid name="lnd">ne30np4.pg3</grid>
@@ -412,49 +419,7 @@
     <mask>tnx0.5v1</mask>
   </model_grid>
 
-  <model_grid alias="ne30_ne30_mg17" not_compset="_BLOM">
-    <grid name="atm">ne30np4</grid>
-    <grid name="lnd">ne30np4</grid>
-    <grid name="ocnice">ne30np4</grid>
-    <mask>tnx1v4</mask>
-  </model_grid>
-
-  <model_grid alias="ne60_g17" not_compset="_BLOM">
-    <grid name="atm">ne60np4</grid>
-    <grid name="lnd">ne60np4</grid>
-    <grid name="ocnice">gx1v7</grid>
-    <mask>gx1v7</mask>
-  </model_grid>
-  <model_grid alias="ne120_g17" not_compset="_BLOM">
-    <grid name="atm">ne120np4</grid>
-    <grid name="lnd">ne120np4</grid>
-    <grid name="ocnice">gx1v7</grid>
-    <mask>gx1v7</mask>
-  </model_grid>
-
-  <model_grid alias="ne120_t12" not_compset="_BLOM">
-    <grid name="atm">ne120np4</grid>
-    <grid name="lnd">ne120np4</grid>
-    <grid name="ocnice">tx0.1v2</grid>
-    <mask>tx0.1v2</mask>
-  </model_grid>
-  <model_grid alias="ne120_ne120_mg17" not_compset="_BLOM">
-    <grid name="atm">ne120np4</grid>
-    <grid name="lnd">ne120np4</grid>
-    <grid name="ocnice">ne120np4</grid>
-    <mask>gx1v7</mask>
-  </model_grid>
-
-  <!--  spectral element grids using trigrid -->
-  <model_grid alias="ne30pg3_f09_tn14">
-    <grid name="atm">ne30np4.pg3</grid>
-    <grid name="lnd">0.9x1.25</grid>
-    <grid name="ocnice">tnx1v4</grid>
-    <mask>tnx1v4</mask>
-  </model_grid>
-
   <!--  spectral element grids with 3x3 FVM physics grid -->
-
   <model_grid alias="ne3pg3_ne3pg3_mtn14" not_compset="_BLOM">
     <grid name="atm">ne3np4.pg3</grid>
     <grid name="lnd">ne3np4.pg3</grid>


### PR DESCRIPTION
Added new aliases ne16pg3 with gris4/ais8 for removed unneeded aliases like ne30, ne60, ne120 and trigrid

The following tests were run and were bfb using noresm3_0_beta16 with the following changes:
- noresm: https://github.com/NorESMhub/NorESM/pull/807
- cmeps: https://github.com/NorESMhub/CMEPS/pull/48
- ww3: https://github.com/NorESMhub/WW3/pull/21