### PR TITLE
Restore ccs_config_noresm0.0.68 settings for gnu compiler

### DIFF
--- a/machines/olivia/config_machines.xml
+++ b/machines/olivia/config_machines.xml
@@ -49,10 +49,11 @@
       <command name="load">NRIS/CPU</command>
       <command name="use">/cluster/projects/nn9560k/software/modules/all/</command>
       <command name="load">git/2.45.1-GCCcore-13.3.0</command>
-      <command name="load">ESMF/8.8.0-foss-2024a-ParallelIO-2.6.5</command>
-      <command name="load">Python/3.12.3-GCCcore-13.3.0</command>
-      <command name="load">CMake/3.29.3-GCCcore-13.3.0</command>
-      <command name="load">XML-LibXML/2.0210-GCCcore-13.3.0</command>
+      <command name="load">ESMF/8.8.0-foss-2023b-ParallelIO-2.6.5</command>
+      <command name="load">Python/3.11.5-GCCcore-13.2.0</command>
+      <command name="load">CMake/3.27.6-GCCcore-13.2.0</command>
+      <command name="load">XML-LibXML/2.0210-GCCcore-13.2.0</command>
+
     </modules>
   </module_system>
   <environment_variables>


### PR DESCRIPTION
This PR just restores the GNU compiler settings for Olivia to those in ccs_config_noresm0.0.68
A hybrid run of the aux_cam_noresm test suite passed for both Intel and GNU.