### PR TITLE
generalized ais8gris4 grid alias to account for new dglc capability i…

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -357,7 +357,7 @@
     <mask>tnx1v4</mask>
   </model_grid>
 
-  <model_grid alias="ne16pg3_tn14_ais8gris4" compset="CISM2%AIS-EVOLVE%GRIS-EVOLVE">
+  <model_grid alias="ne16pg3_tn14_ais8gris4" compset="_CISM2%AIS-EVOLVE%GRIS-EVOLVE|_CISM2%AIS-NOEVOLVE%GRIS-EVOLVE|_CISM2%AIS-EVOLVE%GRIS-NOEVOLVE">
     <grid name="atm">ne16np4.pg3</grid>
     <grid name="lnd">ne16np4.pg3</grid>
     <grid name="ocnice">tnx1v4</grid>


### PR DESCRIPTION
This change is needed to bring in the new dglc capability in CISM. With the new CISM updates - the following 4 new tests pass:
SMS_D_Ld1.ne16pg3_tn14_ais8gris4.NHistEsmGaxg.olivia_intel.allactive-defaultio
ERS_Ld5.ne16pg3_tn14_ais8gris4.NHistEsmGaxg.olivia_intel.allactive-defaultio
SMS_D_Ld1.ne16pg3_tn14_ais8gris4.N1850EsmGaxg.olivia_intel.allactive-defaultio
ERS_Ld5.ne16pg3_tn14_ais8gris4.N1850Gaxg.olivia_intel.allactive-defaultio
